### PR TITLE
publishing scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Custom things to ignore
+build

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+coverage = true

--- a/package.json
+++ b/package.json
@@ -1,14 +1,29 @@
 {
   "name": "easypubsub",
+  "version": "0.0.1",
+  "author": {
+    "name": "Tongtwist",
+    "url": "https://github.com/tongtwist"
+  },
   "module": "src/index.ts",
   "type": "module",
   "scripts": {
+    "build": "bun run build:js && bun run build:types",
+    "build:js": "bun build src/index.ts --outdir ./build --minify",
+    "build:types": "tsc src/index.ts --strict --skipLibCheck --declaration --emitDeclarationOnly --outDir ./build",
+    "publish": " bun test && bun run build && bun publish",
     "ts:watch": "tsc --watch --noEmit"
   },
   "devDependencies": {
-    "@types/bun": "latest"
-  },
-  "peerDependencies": {
+    "@types/bun": "latest",
     "typescript": "^5.7.3"
-  }
+  },
+  "keywords": [
+    "pubsub",
+    "publisher",
+    "subscriber",
+    "zero-dependency",
+    "topic-filtering",
+    "content-filtering"
+  ]
 }


### PR DESCRIPTION
Publish to Npm using no external tools but Bun and Typescript.
To publish:
`bun run publish`
